### PR TITLE
Setup credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage
 .ruby-version
 node_modules
 public/javascripts/lib
+credentials

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The web app for Survival's donation system.
 
 ### To initialise the project
 
-Run the setup script:
+Run the setup script (**Beware:** Needs permissions to access the credentials repo):
 
 ```
 . scripts/setup.sh
@@ -21,6 +21,7 @@ This script will:
 * download [the last jasmine release](https://github.com/jasmine/jasmine/releases) for the JS tests in a `temp` directory
 * unzip it and copy the `lib` folder inside of the `public/javascripts/` folder
 * delete the `temp` directory
+* download the credentials
 * run `npm install` to install the node packages
 * run `bundle install` to install gems.
 * run `bundle exec rake` to run the tests.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "uglify": "uglifyjs public/javascripts/src/index.js public/javascripts/src/bye.js -c -m -o public/javascripts/bundle.js",
     "watch:js": "watch 'npm run uglify && npm run linter' public/javascripts/src public/javascripts/spec",
     "watch:erb": "watch 'bundle exec rake' views",
-    "test": "bundle exec rackup & npm run watch:js & npm run watch:erb & wait"
+    "test": ". credentials/.env_test && bundle exec rackup & npm run watch:js & npm run watch:erb & wait"
   },
   "repository": {
     "type": "git",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,7 @@
 
 main() {
   . scripts/setup_jasmine.sh
+  . scripts/setup_credentials.sh
   npm install
   bundle install
   bundle exec rake

--- a/scripts/setup_credentials.sh
+++ b/scripts/setup_credentials.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+ensure_right_directory() {
+  RELATIVE_ROOT_DIR="$(dirname ${BASH_SOURCE[0]})"/..
+  cd $RELATIVE_ROOT_DIR
+}
+
+extract_latest_credentials() {
+  CREDENTIALS_REPO_URL='https://gitlab.com/survival/donation-system-credentials.git'
+  CREDENTIALS_DIR='credentials'
+
+  if [ -d "$CREDENTIALS_DIR" ]
+  then
+    (cd "$CREDENTIALS_DIR" && git fetch origin && git reset --hard origin/master)
+  else
+    git clone "$CREDENTIALS_REPO_URL" "$CREDENTIALS_DIR"
+  fi
+}
+
+run_credentials() {
+  echo "Running credentials ..."
+  . credentials/.env_test
+}
+
+main() {
+  ensure_right_directory
+  extract_latest_credentials
+  run_credentials
+}
+
+main


### PR DESCRIPTION
This is a PR in preparation for the Stripe integration with the frontend.

In order to run the tests we need to run Stripe in test mode, for which we need to set up the public stripe test key. This PR adds a script to the setup so that the credentials are fetched automatically when you first run the setup.

In the future, when we use the donation-system gem in this webapp, we will need the salesforce credentials as well, which are in the credentials repo as well.