### PR TITLE
Presenters

### DIFF
--- a/lib/donation_system_webapp.rb
+++ b/lib/donation_system_webapp.rb
@@ -2,11 +2,13 @@
 
 require 'sinatra'
 require_relative 'donations'
+require_relative 'page/success'
 
 class DonationSystemWebapp < Sinatra::Base
   set :views, "#{settings.root}/../views"
   set :public_folder, "#{settings.root}/../public"
   set :stripe_public_key, ENV['STRIPE_PUBLIC_KEY']
+  set :assets, 'https://s3.amazonaws.com/assets-production.survivalinternational.org'
 
   get '/' do
     erb :home
@@ -20,6 +22,7 @@ class DonationSystemWebapp < Sinatra::Base
   end
 
   post '/donations' do
+    @page = Page::Success.new(settings.assets)
     erb :success
   end
 end

--- a/lib/donation_system_webapp.rb
+++ b/lib/donation_system_webapp.rb
@@ -2,6 +2,7 @@
 
 require 'sinatra'
 require_relative 'donations'
+require_relative 'page/error'
 require_relative 'page/success'
 
 class DonationSystemWebapp < Sinatra::Base
@@ -17,7 +18,7 @@ class DonationSystemWebapp < Sinatra::Base
   post '/donations' do
     errors = Donations.donate(params)
     pass if errors.empty?
-    @errors = errors
+    @page = Page::Error.new(errors)
     erb :error
   end
 

--- a/lib/donation_system_webapp.rb
+++ b/lib/donation_system_webapp.rb
@@ -3,6 +3,7 @@
 require 'sinatra'
 require_relative 'donations'
 require_relative 'page/error'
+require_relative 'page/home'
 require_relative 'page/success'
 
 class DonationSystemWebapp < Sinatra::Base
@@ -12,6 +13,7 @@ class DonationSystemWebapp < Sinatra::Base
   set :assets, 'https://s3.amazonaws.com/assets-production.survivalinternational.org'
 
   get '/' do
+    @page = Page::Home.new
     erb :home
   end
 

--- a/lib/page/error.rb
+++ b/lib/page/error.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Page
+  class Error
+    ERROR_UI = {
+      title: 'Error',
+      explanation: 'There was a problem with the processing of your payment',
+      retry_message: 'Would you like to try again?'
+    }.freeze
+
+    STRIPE_ERRORS = {
+      missing_data: 'No data was sent with the request.',
+      invalid_amount: 'The amount was missing, or it was not a valid number.',
+      invalid_currency: 'The currency was missing, or unrecognizable.',
+      missing_token: 'The payment gateway could not process the card details.',
+      missing_email: 'The email was missing or had typos.',
+      too_many_requests: 'The payment gateway server is busy. Try again later',
+      connection_problems: 'We had a problem connecting to the payment gateway',
+      stripe_error: 'We had a generic problem with the payment gateway.',
+      unknown_error: 'There was an unknown error. Please try again.',
+      invalid_api_key: 'The credentials for the payment gateway were invalid',
+      invalid_parameter: 'The request contained an invalid parameter',
+      declined_card: 'The card was declined by the bank',
+      invalid_response_object: 'The payment gateway response was invalid'
+    }.freeze
+
+    def initialize(errors)
+      @errors = errors
+    end
+
+    def title
+      ui(:title)
+    end
+
+    def ui(code)
+      ERROR_UI[code]
+    end
+
+    def error_list
+      errors.map do |error_code|
+        STRIPE_ERRORS.fetch(error_code, error_code.to_s)
+      end
+    end
+
+    private
+
+    attr_reader :errors
+  end
+end

--- a/lib/page/error.rb
+++ b/lib/page/error.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'form'
+
 module Page
   class Error
     ERROR_UI = {
@@ -40,6 +42,10 @@ module Page
       errors.map do |error_code|
         STRIPE_ERRORS.fetch(error_code, error_code.to_s)
       end
+    end
+
+    def form
+      Form.new
     end
 
     private

--- a/lib/page/form.rb
+++ b/lib/page/form.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Page
+  class Form
+    FORM_UI = {
+      donation_type: 'This is a one-off donation.',
+      currency: 'Your currency is GBP.',
+      amount: 'Amount in £:',
+      giftaid_title: 'Increase your donation by 25%',
+      giftaid_description: %(If you are a UK tax payer, the
+        value of your gift can be increased by 25% under the Gift
+        Aid scheme at no extra cost to you.),
+      giftaid_yes_title: 'I am a UK taxpayer',
+      giftaid_yes_description: %(and want to Gift Aid my
+        donation to Survival and any donations I make in the future
+        or have made in the past four years. I understand that if
+        I pay less Income Tax and/or Capital Gains Tax than the
+        amount of Gift Aid claimed on all my donations in that tax
+        year it is my responsibility to pay any difference.),
+      giftaid_no_title: 'No, I am not a UK taxpayer',
+      giftaid_no_description: %(or I do not want Survival to
+        reclaim tax on my donations.),
+      payment_method: 'Payment via Credit card',
+      submit_button: 'Donate now',
+      stripe_description: 'Your donation'
+    }.freeze
+
+    def ui(code)
+      FORM_UI[code]
+    end
+  end
+end

--- a/lib/page/home.rb
+++ b/lib/page/home.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'form'
+
+module Page
+  class Home
+    HOME_UI = {
+      title: 'Make a donation'
+    }.freeze
+
+    def title
+      HOME_UI[:title]
+    end
+
+    def form
+      Form.new
+    end
+  end
+end

--- a/lib/page/success.rb
+++ b/lib/page/success.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Page
+  class Success
+    SUCCESS_UI = {
+      title: 'Thanks for your donation',
+      image_url: 'pictures/10712/baiga-briefing_original.jpg',
+      image_width: '808',
+      image_height: '483',
+      image_description: 'Baiga briefing original picture',
+      body: %(Lorem ipsum dolor sit amet consectetur adipiscing
+        elit nibh' 'dignissim suspendisse, imperdiet scelerisque
+        odio consequat proin hendrerit fusce leo' 'at eros, maecenas
+        arcu risus integer egestas sed facilisis tellus vivamus.),
+      share_this_title: 'Tell the world about your contribution'
+    }.freeze
+
+    def initialize(images_baseurl)
+      @images_baseurl = images_baseurl
+    end
+
+    def title
+      ui(:title)
+    end
+
+    def image_url
+      "#{images_baseurl}/#{ui(:image_url)}"
+    end
+
+    def ui(code)
+      SUCCESS_UI[code]
+    end
+
+    private
+
+    attr_reader :images_baseurl
+  end
+end

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -116,7 +116,10 @@ input[type=number] {
   line-height: 2;
 }
 
-
+img {
+  max-width: 100%;
+  height: auto;
+}
 
 
 

--- a/spec/page/error_spec.rb
+++ b/spec/page/error_spec.rb
@@ -28,5 +28,9 @@ module Page
       page = described_class.new([:i_have_no_description_yet])
       expect(page.error_list).to include('i_have_no_description_yet')
     end
+
+    it 'has a form presenter' do
+      expect(page.form.ui(:submit_button)).not_to be_nil
+    end
   end
 end

--- a/spec/page/error_spec.rb
+++ b/spec/page/error_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper.rb'
+require_relative '../../lib/page/error'
+
+module Page
+  RSpec.describe Error do
+    let(:page) { described_class.new([:missing_data]) }
+
+    it 'has a title' do
+      expect(page.title).not_to be_nil
+    end
+
+    it 'has an explanation' do
+      expect(page.ui(:explanation)).not_to be_nil
+    end
+
+    it 'has a message to invite supporter to try again' do
+      expect(page.ui(:retry_message)).not_to be_nil
+    end
+
+    it 'formats errors' do
+      ui_error_description = described_class::STRIPE_ERRORS[:missing_data]
+      expect(page.error_list).to include(ui_error_description)
+    end
+
+    it 'returns the error code if there is no description for it' do
+      page = described_class.new([:i_have_no_description_yet])
+      expect(page.error_list).to include('i_have_no_description_yet')
+    end
+  end
+end

--- a/spec/page/form_spec.rb
+++ b/spec/page/form_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper.rb'
+require_relative '../../lib/page/form'
+
+module Page
+  RSpec.describe Form do
+    let(:form_presenter) { described_class.new }
+
+    it 'has a donation_type' do
+      expect(form_presenter.ui(:donation_type)).not_to be_nil
+    end
+
+    it 'has a currency' do
+      expect(form_presenter.ui(:currency)).not_to be_nil
+    end
+
+    it 'has a amount' do
+      expect(form_presenter.ui(:amount)).not_to be_nil
+    end
+
+    it 'has a giftaid_title' do
+      expect(form_presenter.ui(:giftaid_title)).not_to be_nil
+    end
+
+    it 'has a giftaid_description' do
+      expect(form_presenter.ui(:giftaid_description)).not_to be_nil
+    end
+
+    it 'has a giftaid_yes_title' do
+      expect(form_presenter.ui(:giftaid_yes_title)).not_to be_nil
+    end
+
+    it 'has a giftaid_yes_description' do
+      expect(form_presenter.ui(:giftaid_yes_description)).not_to be_nil
+    end
+
+    it 'has a giftaid_no_title' do
+      expect(form_presenter.ui(:giftaid_no_title)).not_to be_nil
+    end
+
+    it 'has a giftaid_no_description' do
+      expect(form_presenter.ui(:giftaid_no_description)).not_to be_nil
+    end
+
+    it 'has a payment_method' do
+      expect(form_presenter.ui(:payment_method)).not_to be_nil
+    end
+
+    it 'has a submit_button' do
+      expect(form_presenter.ui(:submit_button)).not_to be_nil
+    end
+
+    it 'has a stripe_description' do
+      expect(form_presenter.ui(:stripe_description)).not_to be_nil
+    end
+
+    it 'returns nothing if no ui description available' do
+      expect(form_presenter.ui(:i_dont_exist_in_the_ui)).to be_nil
+    end
+  end
+end

--- a/spec/page/home_spec.rb
+++ b/spec/page/home_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper.rb'
+require_relative '../../lib/page/home'
+
+module Page
+  RSpec.describe Home do
+    let(:page) { described_class.new }
+
+    it 'has a title' do
+      expect(page.title).not_to be_nil
+    end
+
+    it 'has a form presenter' do
+      expect(page.form.ui(:submit_button)).not_to be_nil
+    end
+  end
+end

--- a/spec/page/success_spec.rb
+++ b/spec/page/success_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper.rb'
+require_relative '../../lib/page/success'
+
+module Page
+  RSpec.describe Success do
+    let(:page) { described_class.new('https://some.baseurl') }
+
+    it 'has a title' do
+      expect(page.title).not_to be_nil
+    end
+
+    it 'has an image' do
+      expect(page.image_url).to include('https://some.baseurl')
+      expect(page.ui(:image_width)).not_to be_nil
+      expect(page.ui(:image_height)).not_to be_nil
+      expect(page.ui(:image_description)).not_to be_nil
+    end
+
+    it 'has a body' do
+      expect(page.ui(:body)).not_to be_nil
+    end
+
+    it 'has a social share section' do
+      expect(page.ui(:share_this_title)).not_to be_nil
+    end
+  end
+end

--- a/spec/routes/donations_spec.rb
+++ b/spec/routes/donations_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Donations route' do
     before(:all) { post '/donations', 'foo' => 'bar', 'bar' => 'qux' }
 
     it 'sends errors to the view' do
-      expect(last_response.body).to include('invalid_amount')
+      expect(last_response.body).to include('amount')
     end
 
     it 'loads the donation form' do

--- a/views/_form.erb
+++ b/views/_form.erb
@@ -1,21 +1,23 @@
 <form action="/donations" method="post" id="payment-form">
-  <p>This is a one-off donation.</p>
-  <p>Your currency is GBP</p>
+  <p><%= @page.form.ui(:donation_type) %></p>
+  <p><%= @page.form.ui(:currency) %></p>
   <p>
-    <label for="amount">Amount in £</label>
+    <label for="amount"><%= @page.form.ui(:amount) %></label>
     <input name="amount" type="number" id="amount" min="0.00" step="0.01" required />
   </p>
+  <h2><%= @page.form.ui(:giftaid_title) %></h2>
+  <p><%= @page.form.ui(:giftaid_description) %></p>
   <p>
     <input id="giftaid-yes" type="radio" name="giftaid" value="yes">
-    <label for="giftaid-yes">I am a UK taxpayer</label>
+    <label for="giftaid-yes"><strong><%= @page.form.ui(:giftaid_yes_title) %></strong> <%= @page.form.ui(:giftaid_yes_description) %></label>
   </p>
   <p>
     <input id="giftaid-no" type="radio" name="giftaid" value="no">
-    <label for="giftaid-no">No, I am not a UK taxpayer</label>
+    <label for="giftaid-no"><strong><%= @page.form.ui(:giftaid_no_title) %></strong> <%= @page.form.ui(:giftaid_no_description) %></label>
   </p>
-  <p>Payment via Credit card</p>
+  <p><%= @page.form.ui(:payment_method) %></p>
   <p>
-    <button id="submit-button" type="submit">Donate now</button>
+    <button id="submit-button" type="submit"><%= @page.form.ui(:submit_button) %></button>
   </p>
 </form>
 
@@ -42,7 +44,7 @@
 
   checkoutParams = {
     name: 'Survival International',
-    description: 'Your donation',
+    description: '<%= @page.form.ui(:stripe_description) %>',
     currency: 'GBP',
     billingAddress: true,
     zipCode: true

--- a/views/error.erb
+++ b/views/error.erb
@@ -1,5 +1,13 @@
-<h1>There was a problem with the processing of your payment</h1>
+<h1><%= @page.title %></h1>
 
-<%= @errors %>
+<p><%= @page.ui(:explanation) %></p>
+
+<ul>
+<% @page.error_list.each do |error| %>
+  <li><%= error %></li>
+<% end %>
+</ul>
+
+<h2><%= @page.ui(:retry_message) %></h2>
 
 <%= erb :_form %>

--- a/views/home.erb
+++ b/views/home.erb
@@ -1,2 +1,2 @@
-<h1>Your donation</h1>
+<h1><%= @page.title %></h1>
 <%= erb :_form %>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>Donate - Survival International</title>
+    <title><%= @page.title %></title>
     <meta name="description" content="Survival helps tribal peoples defend their lives, protect their lands and determine their own futures.">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -23,7 +23,6 @@
     <%= yield %>
     </div>
 
-
     <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
   </body>
 </html>

--- a/views/success.erb
+++ b/views/success.erb
@@ -1,1 +1,17 @@
-<h1>Thanks for your donation</h1>
+<h1><%= @page.title %></h1>
+
+<img
+  src="<%= @page.image_url %>"
+  width="<%= @page.ui(:image_width) %>"
+  height="<%= @page.ui(:image_height) %>"
+  alt="<%= @page.ui(:image_description) %>">
+
+<p><%= @page.ui(:body) %></p>
+
+<h2><%= @page.ui(:share_this_title) %></h2>
+
+<p class="sharethis-inline-share-buttons"></p>
+
+<script
+  type="text/javascript"
+  src="https://platform-api.sharethis.com/js/sharethis.js#property=5a0ca6aacab38e0011129c35&amp;product=inline-share-buttons"></script>


### PR DESCRIPTION
This PR adds presenters for the webapp views, to keep logic out of the views and avoid having to test them.

Hopefully this will help in the future with translations as well, but it's too early to say now.

I started thinking about the content, for example, the thank you page shows an image according to Christian's designs. For now I am using our current CDN at Amazon, but we may want to sit and think of what would be the best CDN solution for this webapp, so that we can save images and assets like CSS or the JS bundle.

I also introduced Share This for the sharing buttons, since I know of them for a long time now and they have support for wassap share, which the Spanish office wanted. Share This also does some analytics on the clicks that could be useful for campaigners or anybody looking at that kind of stats.

All the copy in the UI hashes can be improved of course, this text bits are just placeholders for now, until this is finished and somebody from the supporter team has better suggestions.

## Screenshots

### Error view

The error view, showing all possible errors that the app can throw. Error messages are placeholders and can be improved.

![error](https://user-images.githubusercontent.com/2157089/32898298-ae3d17c8-cadf-11e7-8948-a45cd508f4c1.png)

### Success view

The thank you page is unstyled, but is showing the Share This widget which also contains the wassap button, since the Spanish office asked to have it (we should look into adding it to Mailchimp and maybe news pages as well)

![success](https://user-images.githubusercontent.com/2157089/32898346-d1c93cf8-cadf-11e7-9150-4ddbe24ef88e.png)

