### PR TITLE
Issue #35: Update to Ruby 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: ruby
+rvm:
+  - 2.5
 cache: bundler
 script:
   - bundle exec rake
   - npm run linter
 before_install:
+  - gem update --system
   - bundle install
   - nvm install node
   - nvm use node

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '2.4.1'
+ruby '2.5.0'
 
 gem 'donation_system', git: 'https://github.com/survival/donation-system',
                        tag: 'v0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ DEPENDENCIES
   sinatra
 
 RUBY VERSION
-   ruby 2.4.1p111
+   ruby 2.5.0p0
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Updated project to Ruby 2.5.0. 

**Initial setup** 
-Had to comment out the `setup_credentials.sh` script due to credentials errors in setup.
-As indicated in our messaging, I did get that one `Sinatra globals sets Stripe public key` error. 
-Loaded Rackup and site loaded successfully.

**Update to 2.5.0**
-Updated the Gemfile to `Ruby 2.5.0`.
-Ran `bundle`, no individual gems required to be updated.
-Tests reflected same as during initial setup.
-Loaded Rackup and site loaded successfully.
-Ran all tests on README, appears this updated `public/css/main.css` file.
-Updated `.travis.yml` file to indicated new Ruby version.

